### PR TITLE
Develop/v1.0.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tango",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tango",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "dependencies": {
         "papaparse": "^5.5.2",
         "react": "^19.1.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tango",
   "private": true,
-  "version": "1.0.2",
+  "version": "1.0.3",
   "type": "module",
   "scripts": {
     "dev": "vite --force",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,8 +1,7 @@
 import React from 'react'
-import { BrowserRouter, Routes, Route, Link } from 'react-router-dom'
+import { HashRouter, Routes, Route, Link } from 'react-router-dom'
 import './App.css'
 import { loadWords } from './utils'
-// 使用されていないインポートを削除
 
 // コンポーネントのインポート
 import Flashcards from './components/Flashcards'
@@ -44,7 +43,7 @@ function App() {
   console.log('Appコンポーネントがレンダリングされました');
   
   return (
-    <BrowserRouter>
+    <HashRouter>
       <div className="app-container">
         <Routes>
           <Route path="/" element={<Home />} />
@@ -53,7 +52,7 @@ function App() {
           <Route path="/upload" element={<Upload />} />
         </Routes>
       </div>
-    </BrowserRouter>
+    </HashRouter>
   );
 }
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -19,5 +19,5 @@ export default defineConfig({
     // historyApiFallbackはVite 4.x以降では不要、代わりにbase設定を使用
   },
   // ベースパスを設定
-  base: '/tanGo/'
+  base: './'
 })


### PR DESCRIPTION
このプルリクエストには、プロジェクト構成とルーティング実装の更新が含まれています。最も重要な変更点は、ルーティングを `BrowserRouter` から `HashRouter` に切り替え、Vite 構成のベースパスを更新し、`package.json` のプロジェクトバージョンをインクリメントすることです。

### ルーティングの更新:
* ルーティングを管理するために、`src/App.tsx` 内の `BrowserRouter` を `HashRouter` に置き換えました。これにより、サーバー側ルーティングがサポートされていない環境との互換性が確保されます。 [[1]](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2L2-L5) [[2]](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2L47-R46) [[3]](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2L56-R55)

### 設定の更新:
* `vite.config.ts` の `base` パスを `/tanGo/` から `./` に変更し、デプロイパスを簡素化しました。
* `package.json` のプロジェクトバージョンを `1.0.2` から `1.0.3` に増加しました。